### PR TITLE
Typo fix in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def merge_data(*data_sources):
       "channel": "stable-channel",
       "last_modified": 0,
       "url": "https://github.com/MercuryWorkshop/chromeos-releases-data",
-      "__licnese": "https://github.com/MercuryWorkshop/chromeos-releases-data/blob/main/LICENSE",
+      "__license": "https://github.com/MercuryWorkshop/chromeos-releases-data/blob/main/LICENSE",
       "__license_info": "JSON data is licensed under the Creative Commons Attribution license. If you use this for your own projects, you must include attribution and link to the repository."
     })
     images.sort(key=lambda x: x["last_modified"])


### PR DESCRIPTION
In the newest commit (at the time of writing) [b94e09d](https://github.com/MercuryWorkshop/chromeos-releases/commit/b94e09d44c0d901ca5363b4b719466e7aad4c5dc) contains a typo which has `license` incorrectly spelled as `licnese`. This PR fixes that typo.