### PR TITLE
Fixed more capitalization in cron_archive.sh

### DIFF
--- a/cron_archive.sh
+++ b/cron_archive.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#this script triggers internet archive snapshots for the following urls
+# This script triggers Internet Archive snapshots for the following URLs
 
 urls=(
   "https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=ChromeOS"


### PR DESCRIPTION
I fixed more language related issues, as I believe it would be for the greater good of society! In this PR, I changed one single line. It pmo (pissed me off) sm (so much) that I js (just) had to do smthn (something) abt (about) it.

```diff
- #this script triggers internet archive snapshots for the following urls
+ # This script triggers Internet Archive snapshots for the following URLs
```

It's always good to see more contributions to FOSS projects, am I right?